### PR TITLE
fix(gui): anchor PROG: line match so log lines are not silenced (#33)

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,11 +8,12 @@ import runpy
 import io
 import difflib # Forzamos la inclusión para PyInstaller
 import locale
-import re
 from PIL import Image
 from dotenv import load_dotenv
 import tqdm
 import spotipy
+
+from utils.progress_line import parse_progress_line
 
 # --- CORRECCIÓN DE CODIFICACIÓN PARA EMOJIS EN WINDOWS ---
 if sys.stdout is not None and hasattr(sys.stdout, 'reconfigure'):
@@ -320,17 +321,15 @@ class SpotifyToolkitApp(ctk.CTk):
 
     def add_log_raw(self, text):
         def _append():
-            # Capturar progreso para la barra (Formato PROG:XX)
-            if "PROG:" in text:
-                try:
-                    # Extraer el número del progreso
-                    match = re.search(r"PROG:(\d+)", text)
-                    if match:
-                        percent = int(match.group(1))
-                        self.progress_bar.set(percent / 100)
-                    return # No imprimir líneas de progreso en la consola
-                except:
-                    pass
+            # Lines that are *entirely* a `PROG:<N>` directive (with
+            # optional whitespace and CR/LF trailers) are routed to the
+            # progress bar and never echoed to the log. Ordinary log
+            # messages that happen to contain "PROG:" mid-sentence
+            # (e.g. "Logging PROG:50 ok") flow through unchanged.
+            percent = parse_progress_line(text)
+            if percent is not None:
+                self.progress_bar.set(percent / 100)
+                return
 
             self.log_textbox.configure(state="normal")
             self.log_textbox.insert("end", text)

--- a/tests/test_progress_line.py
+++ b/tests/test_progress_line.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+# Add project root to sys.path so `utils.progress_line` is importable.
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.append(project_root)
+
+from utils.progress_line import parse_progress_line
+
+
+def test_plain_progress_line_is_recognised():
+    assert parse_progress_line("PROG:50\n") == 50
+
+
+def test_progress_line_with_crlf_is_recognised():
+    assert parse_progress_line("PROG:0\r\n") == 0
+
+
+def test_progress_line_with_leading_whitespace_is_recognised():
+    assert parse_progress_line("  PROG:99\n") == 99
+
+
+def test_progress_line_at_one_hundred_is_recognised():
+    assert parse_progress_line("PROG:100\n") == 100
+
+
+def test_embedded_prog_substring_is_passed_through():
+    # Real fix: ordinary log messages that happen to mention "PROG:"
+    # mid-sentence must NOT be silenced. Previously the GUI used
+    # `if "PROG:" in text` which incorrectly swallowed lines like this.
+    assert parse_progress_line("Logging PROG:50 ok\n") is None
+
+
+def test_progress_line_with_extra_text_is_passed_through():
+    assert parse_progress_line("PROG:50 then more\n") is None
+
+
+def test_non_numeric_progress_is_not_recognised():
+    assert parse_progress_line("PROG:abc\n") is None
+
+
+def test_empty_input_is_not_recognised():
+    assert parse_progress_line("") is None
+    assert parse_progress_line(None) is None  # type: ignore[arg-type]
+
+
+def test_plain_log_line_is_passed_through():
+    assert parse_progress_line("Doing stuff\n") is None
+
+
+if __name__ == "__main__":
+    # Allow running directly: `python tests/test_progress_line.py`.
+    test_plain_progress_line_is_recognised()
+    test_progress_line_with_crlf_is_recognised()
+    test_progress_line_with_leading_whitespace_is_recognised()
+    test_progress_line_at_one_hundred_is_recognised()
+    test_embedded_prog_substring_is_passed_through()
+    test_progress_line_with_extra_text_is_passed_through()
+    test_non_numeric_progress_is_not_recognised()
+    test_empty_input_is_not_recognised()
+    test_plain_log_line_is_passed_through()
+    print("[OK] all parse_progress_line tests passed")

--- a/utils/progress_line.py
+++ b/utils/progress_line.py
@@ -1,0 +1,42 @@
+"""Helpers for recognising progress-bar control lines in subprocess output.
+
+Background scripts used by the GUI report progress on stdout via lines
+of the form ``PROG:<N>`` where ``<N>`` is a percentage. The GUI's log
+textbox should never display those control lines — they belong to the
+progress bar widget — and ordinary log lines that *mention* ``PROG:``
+inside a sentence (for example ``"Logging PROG:50 ok"``) should still
+be visible to the user. Anchoring the match to the start of the line
+keeps the two kinds of output cleanly separated.
+
+This module is GUI-free on purpose so it can be unit tested without
+pulling in customtkinter or tkinter.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+# Match a stdout line that is *entirely* a ``PROG:<digits>`` directive,
+# allowing optional surrounding whitespace and CR/LF trailers (``\r\n``,
+# ``\n``, etc.). Substrings inside ordinary log messages will not match.
+_PROG_LINE_RE = re.compile(r"^\s*PROG:(\d+)\s*$")
+
+
+def parse_progress_line(text: str) -> Optional[int]:
+    """Return the integer percentage if ``text`` is a progress directive.
+
+    Returns ``None`` for any line that is not a standalone ``PROG:<N>``
+    directive — including empty strings, ordinary log messages that
+    happen to contain ``PROG:`` mid-sentence, and ``PROG:<non-digits>``.
+    """
+    if not text:
+        return None
+    match = _PROG_LINE_RE.match(text)
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None


### PR DESCRIPTION
Closes #33.

## Summary
- The GUI's `add_log_raw` used `if \"PROG:\" in text` to detect progress directives. That match is too loose: any ordinary log line that mentions `PROG:` mid-sentence (e.g. `\"Logging PROG:50 ok\"`) was silently dropped from the log textbox, and progress directives that arrived with a CR/LF or leading whitespace could leak as artifacts.
- The substring check is replaced with an anchored regex `^\\s*PROG:(\\d+)\\s*$` so a line is consumed by the progress bar **only** when it is *entirely* a `PROG` directive. Mid-line mentions flow through to the log textbox unchanged.
- The matcher is split out into a GUI-free helper `utils/progress_line.py::parse_progress_line` so the rule is unit-testable without pulling in customtkinter; `main.py` drops its now-unused `import re`.

## Behavior
| Input line                | Before                                  | After                          |
|---------------------------|-----------------------------------------|--------------------------------|
| `PROG:50\\n`               | progress bar updates, line hidden       | same                           |
| `  PROG:0\\r\\n`            | progress bar updates, line hidden       | same                           |
| `Logging PROG:50 ok\\n`    | line hidden (bug — log lost)            | line shown in log textbox      |
| `PROG:50 then more\\n`     | progress bar updates, line hidden       | line shown in log textbox      |
| `output\\n`                | line shown                              | same                           |

## Test plan
- [x] Added `tests/test_progress_line.py` with 9 cases: plain, CRLF, leading whitespace, 100%, embedded substring, trailing text after `PROG:N`, non-numeric, empty/None input, ordinary log line.
- [x] `python3 -m pytest tests/test_progress_line.py` → `9 passed`.
- [x] `python3 tests/test_progress_line.py` (script form, matching the existing `tests/test_helpers.py` style) → `[OK] all parse_progress_line tests passed`.
- [x] `main.py` parses cleanly (`ast.parse`) after the refactor.