### PR TITLE
fix(gui): suppress blank progress log chunks

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 import tqdm
 import spotipy
 
-from utils.progress_line import parse_progress_line
+from utils.progress_line import is_blank_console_line, parse_progress_line
 
 # --- CORRECCIÓN DE CODIFICACIÓN PARA EMOJIS EN WINDOWS ---
 if sys.stdout is not None and hasattr(sys.stdout, 'reconfigure'):
@@ -329,6 +329,9 @@ class SpotifyToolkitApp(ctk.CTk):
             percent = parse_progress_line(text)
             if percent is not None:
                 self.progress_bar.set(percent / 100)
+                return
+
+            if is_blank_console_line(text):
                 return
 
             self.log_textbox.configure(state="normal")

--- a/tests/test_progress_line.py
+++ b/tests/test_progress_line.py
@@ -6,7 +6,7 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.append(project_root)
 
-from utils.progress_line import parse_progress_line
+from utils.progress_line import is_blank_console_line, parse_progress_line
 
 
 def test_plain_progress_line_is_recognised():
@@ -42,11 +42,25 @@ def test_non_numeric_progress_is_not_recognised():
 
 def test_empty_input_is_not_recognised():
     assert parse_progress_line("") is None
-    assert parse_progress_line(None) is None  # type: ignore[arg-type]
+    assert parse_progress_line(None) is None
 
 
 def test_plain_log_line_is_passed_through():
     assert parse_progress_line("Doing stuff\n") is None
+
+
+def test_blank_console_line_is_suppressed():
+    assert is_blank_console_line("")
+    assert is_blank_console_line("\n")
+    assert is_blank_console_line("\r")
+    assert is_blank_console_line("\r\n")
+    assert is_blank_console_line("   \r\n")
+    assert is_blank_console_line(None)
+
+
+def test_non_blank_console_line_is_not_suppressed():
+    assert not is_blank_console_line("Processing tracks\n")
+    assert not is_blank_console_line("  PROG:50\n")
 
 
 if __name__ == "__main__":
@@ -60,4 +74,6 @@ if __name__ == "__main__":
     test_non_numeric_progress_is_not_recognised()
     test_empty_input_is_not_recognised()
     test_plain_log_line_is_passed_through()
+    test_blank_console_line_is_suppressed()
+    test_non_blank_console_line_is_not_suppressed()
     print("[OK] all parse_progress_line tests passed")

--- a/utils/progress_line.py
+++ b/utils/progress_line.py
@@ -24,7 +24,7 @@ from typing import Optional
 _PROG_LINE_RE = re.compile(r"^\s*PROG:(\d+)\s*$")
 
 
-def parse_progress_line(text: str) -> Optional[int]:
+def parse_progress_line(text: Optional[str]) -> Optional[int]:
     """Return the integer percentage if ``text`` is a progress directive.
 
     Returns ``None`` for any line that is not a standalone ``PROG:<N>``
@@ -40,3 +40,14 @@ def parse_progress_line(text: str) -> Optional[int]:
         return int(match.group(1))
     except (TypeError, ValueError):
         return None
+
+
+def is_blank_console_line(text: Optional[str]) -> bool:
+    """Return ``True`` for output chunks that should not reach the log.
+
+    Progress-producing tools such as ``tqdm`` often emit standalone
+    carriage returns or empty newline chunks while redrawing a progress
+    line. Those chunks create visual blank rows in the GUI console, so the
+    log textbox should ignore them entirely.
+    """
+    return text is None or text.strip() == ""


### PR DESCRIPTION
Closes #33

## Summary
- Treat standalone carriage returns, newlines, and whitespace-only stdout chunks as non-log output.
- Keep `PROG:<N>` parsing in the GUI-free helper module so the filtering behavior stays unit-testable.
- Suppress empty progress redraw artifacts in the textbox while preserving real log lines.

## Issue Evidence
- Issue #33 was reopened after a prior fix because the console still filled with blank rows while progress updates were running.
- Root cause: `main.py:add_log_raw` filtered `PROG:` directives, but still inserted standalone `\r`, `\n`, and whitespace-only chunks into the textbox.
- The GUI now ignores those chunks before writing to the console.

## Verification
- `python tests/test_progress_line.py` — passed.
- `python -m py_compile main.py utils/progress_line.py tests/test_progress_line.py` — passed.
- `git diff --check` — passed.
- LSP diagnostics for `utils/progress_line.py` — clean.
- `main.py` LSP shows environment-level missing dependency warnings (`customtkinter`, `PIL`, `dotenv`, `spotipy`) in this shell, but no change-specific parser/integration errors.

## Community Rules Review
- Focused PR for a single issue/concern.
- Split into two atomic commits: parser/tests, then GUI integration.
- No unauthorized version bump.
- No workflow/tracker/profile files included in the target repo diff.
